### PR TITLE
Add support for de-activating a field (removed from stats)

### DIFF
--- a/src/main/java/de/gwdg/metadataqa/api/configuration/schema/Field.java
+++ b/src/main/java/de/gwdg/metadataqa/api/configuration/schema/Field.java
@@ -7,6 +7,7 @@ public class Field {
   private String path;
   private List<String> categories;
   private boolean extractable;
+  private boolean inactive;
   private List<Rule> rules;
   private String indexField;
 
@@ -40,6 +41,14 @@ public class Field {
 
   public void setExtractable(boolean extractable) {
     this.extractable = extractable;
+  }
+
+  public boolean isInactive() {
+    return inactive;
+  }
+
+  public void setInactive(boolean inactive) {
+    this.inactive = inactive;
   }
 
   public List<Rule> getRules() {

--- a/src/main/java/de/gwdg/metadataqa/api/util/SchemaFactory.java
+++ b/src/main/java/de/gwdg/metadataqa/api/util/SchemaFactory.java
@@ -51,6 +51,9 @@ public class SchemaFactory {
       if (field.isExtractable())
         branch.setExtractable();
 
+      if (field.isInactive())
+        branch.setActive(false);
+
       if (field.getRules() != null)
         branch.setRule(field.getRules());
 


### PR DESCRIPTION
Doesn't seem to be support for setting this in the schema, enabling so fields can be marked as inactive (but can still then be output with their values, useful in combination with echo (#66)