### PR TITLE
Enable categories in field groups to be configurable

### DIFF
--- a/src/main/java/de/gwdg/metadataqa/api/counter/CompletenessCounter.java
+++ b/src/main/java/de/gwdg/metadataqa/api/counter/CompletenessCounter.java
@@ -2,6 +2,7 @@ package de.gwdg.metadataqa.api.counter;
 
 import de.gwdg.metadataqa.api.model.Category;
 import de.gwdg.metadataqa.api.schema.Schema;
+import de.gwdg.metadataqa.api.json.FieldGroup;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -50,10 +51,10 @@ public class CompletenessCounter implements Serializable {
       basicCounters.get(category).increaseInstance();
   }
 
-  public void increaseInstance(Category category, boolean increase) {
-    basicCounters.get(category.name()).increaseTotal();
+  public void increaseInstance(String category, boolean increase) {
+    basicCounters.get(category).increaseTotal();
     if (increase) {
-      basicCounters.get(category.name()).increaseInstance();
+      basicCounters.get(category).increaseInstance();
     }
   }
 
@@ -75,6 +76,9 @@ public class CompletenessCounter implements Serializable {
     headers.add(TOTAL);
     for (String category : schema.getCategories()) {
       headers.add(category);
+    }
+    for (FieldGroup group: schema.getFieldGroups()) {
+      headers.add(group.getCategory());
     }
     return headers;
   }

--- a/src/main/java/de/gwdg/metadataqa/api/json/FieldGroup.java
+++ b/src/main/java/de/gwdg/metadataqa/api/json/FieldGroup.java
@@ -27,7 +27,7 @@ public class FieldGroup {
   /**
    * The sub dimension or category.
    */
-  private Category category;
+  private String category;
 
   /**
    * Construct a new FieldGroup object.
@@ -39,11 +39,15 @@ public class FieldGroup {
    *
    * @see JsonBranch
    */
-  public FieldGroup(Category pCategory, String... pFields) {
-    this.category = pCategory;
-    this.fields = Arrays.asList(pFields);
+  public FieldGroup(String sCategory, List<String> sFields) {
+    this.category = sCategory;
+    this.fields = sFields;
   }
 
+  public FieldGroup(Category pCategory, String... pFields) {
+    this.category = pCategory.toString();
+    this.fields = Arrays.asList(pFields);
+  }
   /**
    * Get the list of field names.
    * @return
@@ -58,7 +62,7 @@ public class FieldGroup {
    * @return
    *   The category
    */
-  public Category getCategory() {
+  public String getCategory() {
     return category;
   }
 

--- a/src/main/java/de/gwdg/metadataqa/api/schema/BaseSchema.java
+++ b/src/main/java/de/gwdg/metadataqa/api/schema/BaseSchema.java
@@ -19,6 +19,7 @@ public class BaseSchema implements Schema, CsvAwareSchema, Serializable {
   private final Map<String, JsonBranch> collectionPaths = new LinkedHashMap<>();
   private final Map<String, JsonBranch> directChildren = new LinkedHashMap<>();
   private Map<String, String> extractableFields = new LinkedHashMap<>();
+  private List<FieldGroup> fieldGroups = new ArrayList<>();
   private List<String> categories = null;
   private List<RuleChecker> ruleCheckers;
   private List<JsonBranch> indexFields;
@@ -88,9 +89,14 @@ public class BaseSchema implements Schema, CsvAwareSchema, Serializable {
     return paths.get(label);
   }
 
+  public BaseSchema addFieldGroup(FieldGroup fieldgroup) {
+    fieldGroups.add(fieldgroup);
+	return this;
+  }
+
   @Override
   public List<FieldGroup> getFieldGroups() {
-    return new ArrayList<>();
+    return fieldGroups;
   }
 
   @Override

--- a/src/main/java/de/gwdg/metadataqa/api/util/SchemaFactory.java
+++ b/src/main/java/de/gwdg/metadataqa/api/util/SchemaFactory.java
@@ -2,7 +2,10 @@ package de.gwdg.metadataqa.api.util;
 
 import de.gwdg.metadataqa.api.configuration.SchemaConfiguration;
 import de.gwdg.metadataqa.api.configuration.schema.Field;
+import de.gwdg.metadataqa.api.configuration.schema.Group;
+import de.gwdg.metadataqa.api.model.Category;
 import de.gwdg.metadataqa.api.json.JsonBranch;
+import de.gwdg.metadataqa.api.json.FieldGroup;
 import de.gwdg.metadataqa.api.schema.BaseSchema;
 import de.gwdg.metadataqa.api.schema.Format;
 import de.gwdg.metadataqa.api.schema.Schema;
@@ -62,6 +65,14 @@ public class SchemaFactory {
 
       schema.addField(branch);
     }
+
+    for (Group group : config.getGroups()) {
+		FieldGroup fieldgroup = new FieldGroup( 
+				group.getCategories().get(0),
+				group.getFields());
+
+		schema.addFieldGroup(fieldgroup);
+	}
 
     if (config.getNamespaces() != null)
       schema.setNamespaces(config.getNamespaces());


### PR DESCRIPTION
As per categories set at the field level, enable categories at the fieldgroup level to be set beyond the enum types