### PR TITLE
Handle categories with same names set either way

### DIFF
--- a/src/main/java/de/gwdg/metadataqa/api/calculator/CompletenessCalculator.java
+++ b/src/main/java/de/gwdg/metadataqa/api/calculator/CompletenessCalculator.java
@@ -118,14 +118,14 @@ public class CompletenessCalculator<T extends XmlFieldInstance>
 
     if (schema.getFieldGroups() != null) {
       for (FieldGroup fieldGroup : schema.getFieldGroups()) {
-        var existing = false;
+        int existing = 0;
+        int field_count = fieldGroup.getFields().size();
         for (String field : fieldGroup.getFields()) {
           if (Boolean.TRUE.equals(existenceCounter.get(field))) {
-            existing = true;
-            break;
+            existing++;
           }
         }
-        completenessCounter.increaseInstance(fieldGroup.getCategory(), existing);
+        completenessCounter.increaseInstance(fieldGroup.getCategory(), existing, field_count);
       }
     }
 

--- a/src/main/java/de/gwdg/metadataqa/api/counter/BasicCounter.java
+++ b/src/main/java/de/gwdg/metadataqa/api/counter/BasicCounter.java
@@ -29,6 +29,14 @@ public class BasicCounter implements Serializable {
     instance++;
   }
 
+  public void decreaseTotal(int decrease) {
+    total -= decrease;
+  }
+
+  public void decreaseInstance(int decrease) {
+    instance -= decrease;
+  }
+
   public void calculate() {
     result = (instance / total);
   }

--- a/src/main/java/de/gwdg/metadataqa/api/counter/CompletenessCounter.java
+++ b/src/main/java/de/gwdg/metadataqa/api/counter/CompletenessCounter.java
@@ -52,10 +52,19 @@ public class CompletenessCounter implements Serializable {
       basicCounters.get(category).increaseInstance();
   }
 
-  public void increaseInstance(String category, boolean increase) {
+  public void increaseInstance(String category, int increase, int field_count) {
+   // Don't increment total if already counted by field category
+   if(basicCounters.get(category).getTotal() == 0)
     basicCounters.get(category).increaseTotal();
-    if (increase) {
-      basicCounters.get(category).increaseInstance();
+
+   if (increase > 0) {
+	  // If count has already been set by fields, we reduce the count down based on fieldgroups
+	  if(basicCounters.get(category).getInstance() > 0) {
+        basicCounters.get(category).decreaseInstance(increase - 1);
+        basicCounters.get(category).decreaseTotal(field_count - 1);
+      } else {
+        basicCounters.get(category).increaseInstance();
+      }
     }
   }
 


### PR DESCRIPTION
Very much WIP. Handles groups with same category name as fields, allowing for subsets of fields with a category to be counted as complete if any one of them is set.
Problems remaining to consider/handle:

  - Does this work for enum type as expected
  - How should this work if there is no overlap between the fields set at field/group level with the same category
  - How should this work if there is only partial overlap 
