### PR TITLE
Don't count empty strings

### DIFF
--- a/src/main/java/de/gwdg/metadataqa/api/calculator/CompletenessCalculator.java
+++ b/src/main/java/de/gwdg/metadataqa/api/calculator/CompletenessCalculator.java
@@ -178,7 +178,7 @@ public class CompletenessCalculator<T extends XmlFieldInstance>
       completenessCounter.increaseTotal(jsonBranch.getCategories());
     }
 
-    if (values != null && !values.isEmpty()) {
+    if (values != null && !values.isEmpty() && !values.get(0).getValue().isEmpty()) {
       handleNonNullValues(completenessCounter, jsonBranch, values);
     } else {
       handleNullValues(jsonBranch);


### PR DESCRIPTION
As mentioned before, for our data all objects contain all the fields in the data model regardless of whether they have values or not. If it is just a string field and it has not been populated, it will be an empty string value, which should not be counted.

This might be something that should be configurable as others might consider the existence of the field in the data proof of completeness regardless of the value.